### PR TITLE
Feat [#127] 특정 태스크의 모립세트 불러오기 API & 자잘한 오류 수정

### DIFF
--- a/jaksim/src/main/java/org/sopt/jaksim/category/facade/CategoryMsetFacade.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/category/facade/CategoryMsetFacade.java
@@ -7,12 +7,14 @@ import org.sopt.jaksim.category.dto.CategoryMsetLinkResponse;
 import org.sopt.jaksim.category.service.CategoryService;
 import org.sopt.jaksim.mset.domain.CategoryMset;
 import org.sopt.jaksim.mset.domain.Mset;
+import org.sopt.jaksim.mset.dto.MsetOfTask;
 import org.sopt.jaksim.mset.service.CategoryMsetService;
 import org.sopt.jaksim.mset.service.MsetService;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -39,6 +41,13 @@ public class CategoryMsetFacade {
 
     public void deleteMsetById(List<Long> msetIdList) {
         msetService.delete(msetIdList);
+    }
+
+    public List<MsetOfTask> getFromCategory(Long categoryId) {
+        return getFromOtherCategory(categoryId).msetList().stream().map(
+                mset -> MsetOfTask.of(mset.getId(), mset.getName(), mset.getUrl())
+        ).collect(Collectors.toList());
+
     }
 
 }

--- a/jaksim/src/main/java/org/sopt/jaksim/category/facade/CategoryTaskFacade.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/category/facade/CategoryTaskFacade.java
@@ -3,6 +3,7 @@ package org.sopt.jaksim.category.facade;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.sopt.jaksim.category.domain.Category;
+import org.sopt.jaksim.category.domain.CategoryTask;
 import org.sopt.jaksim.category.dto.CategoryCheckResponse;
 import org.sopt.jaksim.category.dto.CategoryTaskLink;
 import org.sopt.jaksim.category.dto.FilteredResourceResponse;
@@ -70,10 +71,16 @@ public class CategoryTaskFacade {
     public void delete(Long categoryId) {
         categoryService.delete(categoryId);
     }
+
     public void deleteCategoryTaskAndTasks(Long categoryId) {
         // CategoryTask -> Task 순으로 삭제
         List<Long> taskIdList = categoryTaskService.deleteAndGetTaskIdList(categoryId);
         taskService.delete(taskIdList);
     }
 
+
+
+    public Long getCategoryIdByCategoryTask(Long taskId) {
+        return categoryTaskService.getCategoryIdTaskByTaskId(taskId);
+    }
 }

--- a/jaksim/src/main/java/org/sopt/jaksim/category/repository/CategoryTaskRepository.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/category/repository/CategoryTaskRepository.java
@@ -4,8 +4,9 @@ import org.sopt.jaksim.category.domain.CategoryTask;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface CategoryTaskRepository extends JpaRepository<CategoryTask, Long> {
-    CategoryTask findByTaskId(Long taskId);
+    Optional<CategoryTask> findByTaskId(Long taskId);
     List<CategoryTask> findByCategoryId(Long categoryId);
 }

--- a/jaksim/src/main/java/org/sopt/jaksim/category/service/CategoryTaskService.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/category/service/CategoryTaskService.java
@@ -28,4 +28,10 @@ public class CategoryTaskService {
         categoryTaskRepository.deleteAll(categoryTaskList);
         return taskIdList;
     }
+
+    public Long getCategoryIdTaskByTaskId(Long taskId) {
+        return categoryTaskRepository.findByTaskId(taskId).orElseThrow(
+                () -> new NotFoundException(ErrorMessage.NOT_FOUND)
+        ).getCategoryId();
+    }
 }

--- a/jaksim/src/main/java/org/sopt/jaksim/mset/api/MsetApiController.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/mset/api/MsetApiController.java
@@ -6,14 +6,18 @@ import org.apache.coyote.Response;
 import org.sopt.jaksim.category.api.CategoryApi;
 import org.sopt.jaksim.category.dto.CategoryMsetLinkResponse;
 import org.sopt.jaksim.category.facade.CategoryMsetFacade;
+import org.sopt.jaksim.category.facade.CategoryTaskFacade;
 import org.sopt.jaksim.global.common.ApiResponseUtil;
 import org.sopt.jaksim.global.common.BaseResponse;
 import org.sopt.jaksim.global.message.SuccessMessage;
+import org.sopt.jaksim.mset.dto.MsetOfTask;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @Slf4j
 @RestController
@@ -21,6 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1")
 public class MsetApiController implements MsetApi {
     private final CategoryMsetFacade categoryMsetFacade;
+    private final CategoryTaskFacade categoryTaskFacade;
 
     @GetMapping("/mset/categories/{categoryId}")
     @Override
@@ -28,4 +33,11 @@ public class MsetApiController implements MsetApi {
         CategoryMsetLinkResponse response = categoryMsetFacade.getFromOtherCategory(categoryId);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS, response);
     }
+
+    @GetMapping("/mset/tasks/{taskId}")
+    public ResponseEntity<BaseResponse<?>> getFromOtherTask(@PathVariable("taskId") Long taskId) {
+        List<MsetOfTask> response = categoryMsetFacade.getFromCategory(categoryTaskFacade.getCategoryIdByCategoryTask(taskId));
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS, response);
+    }
+
 }

--- a/jaksim/src/main/java/org/sopt/jaksim/mset/dto/MsetOfTask.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/mset/dto/MsetOfTask.java
@@ -1,0 +1,11 @@
+package org.sopt.jaksim.mset.dto;
+
+public record MsetOfTask(
+        Long id,
+        String name,
+        String url
+) {
+    public static MsetOfTask of(Long id, String name, String url) {
+        return new MsetOfTask(id, name, url);
+    }
+}

--- a/jaksim/src/main/java/org/sopt/jaksim/task/api/TaskApiController.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/task/api/TaskApiController.java
@@ -40,7 +40,7 @@ public class TaskApiController implements TaskApi {
         }
     }
 
-    @PostMapping("/categories/{categoryId}")
+    @PostMapping("/tasks/{categoryId}")
     @Override
     public ResponseEntity<BaseResponse<?>> create(@PathVariable("categoryId") Long categoryId,
                                                   @RequestBody TaskCreateRequest taskCreateRequest) {

--- a/jaksim/src/main/java/org/sopt/jaksim/task/service/TodoService.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/task/service/TodoService.java
@@ -84,7 +84,9 @@ public class TodoService {
                         TaskInTodoCard.of(
                                 task,
                                 taskTimerMap.get(task.getId()),
-                                categoryService.getCategoryById(categoryTaskRepository.findByTaskId(task.getId()).getCategoryId()),
+                                categoryService.getCategoryById(categoryTaskRepository.findByTaskId(task.getId()).orElseThrow(
+                                        () -> new NotFoundException(ErrorMessage.NOT_FOUND)
+                                ).getCategoryId()),
                                 todoTaskMap.get(task.getId()).getTaskOrder()));
             }
         }


### PR DESCRIPTION
## 📍 Issue
closes #127 

## ✨ Key Changes
- 모립세트 불러오기 API 구현했습니다.
- 태스크 생성 API Path `api/v1/categories/{categoryId}` 로 되어있어서 categories -> **tasks** 로 수정했습니다.
- `CategoryTaskRepository.findByTaskId` orElseThrow() 에러 핸들링을 위해 Optional로 변경했습니다.

## 💬 To Reviewers




