### PR TITLE
Fix [#133] 태스크 생성 후 홈뷰 조회 플로우 에러 해결

### DIFF
--- a/jaksim/src/main/java/org/sopt/jaksim/task/service/TaskService.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/task/service/TaskService.java
@@ -56,8 +56,6 @@ public class TaskService {
                 task.getId());
 
         categoryTaskRepository.save(categoryTask);
-
-        taskTimerService.createTaskTimer(task.getId());
     }
 
     public void toggleTaskCompletionStatus(Long taskId) {

--- a/jaksim/src/main/java/org/sopt/jaksim/task/service/TaskTimerService.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/task/service/TaskTimerService.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -26,6 +27,7 @@ public class TaskTimerService {
     public void createTaskTimer(Long taskId) {
         taskTimerRepository.save(TaskTimer.create(3L, taskId));
     }
+
     public void calculateTaskTimerOnStop(Long taskId, StopTimerRequest stopTimerRequest) {
 //        userFacade.getUserByPrincipal().getId()
         TaskTimer taskTimer = taskTimerRepository.findByUserIdAndTargetDateAndTaskId(3L, stopTimerRequest.targetDate(), taskId).orElseThrow(
@@ -41,9 +43,8 @@ public class TaskTimerService {
     }
 
     public int getTaskTimeByTaskId(Long userId, LocalDate targetDate, Long taskId) {
-        TaskTimer taskTimer = taskTimerRepository.findByUserIdAndTargetDateAndTaskId(userId, targetDate, taskId).orElseThrow(
-                () -> new NotFoundException(ErrorMessage.NOT_FOUND)
-        );
-        return taskTimer.getTargetTime();
+        TaskTimer taskTimer = taskTimerRepository.findByUserIdAndTargetDateAndTaskId(userId, targetDate, taskId).orElse(null);
+        if (taskTimer == null) return 0;
+        else return taskTimer.getTargetTime();
     }
 }


### PR DESCRIPTION
## 📍 Issue
closes #133 

## ✨ Key Changes
태스크를 생성할 때 TaskTimer를 즉시 해당 날짜로 생성하는 로직으로 이전 이슈에서 구성했는데, 이렇게 하면 태스크의 시작날짜와 종료날짜까지 일일이 targetDate로 지정해서 TaskTimer를 생성해야 합니다. 
따라서, TaskTimer를 생성하는 것은 오늘 할일에 추가해서 타이머를 시작할 때 생성하고, 홈뷰에서 태스크의 누적시간을 조회할 때는 null이면 0을 반환하도록 했습니다.

## 💬 To Reviewers



