### PR TITLE
Fix [#135] 카테고리 생성 시 startDate null 핸들링

### DIFF
--- a/jaksim/src/main/java/org/sopt/jaksim/category/service/CategoryService.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/category/service/CategoryService.java
@@ -46,7 +46,7 @@ public class CategoryService {
                 categoryCreateRequest.name(),
 //                userFacade.getUserByPrincipal().getId(),
                 3L,
-                categoryCreateRequest.startDate(),
+                categoryCreateRequest.startDate() == null ? LocalDate.now() : categoryCreateRequest.startDate(),
                 categoryCreateRequest.endDate());
         category = categoryRepository.save(category);
         msetService.createByCategory(categoryCreateRequest, category.getId());


### PR DESCRIPTION
## 📍 Issue
closes #135

## ✨ Key Changes
카테고리 생성 시, startDate가 null인 경우 오늘 날짜로 자동 매핑되게 처리했습니다. 
3항 연산자를 사용했습니다.

## 💬 To Reviewers



