### PR TITLE
Fix [#137] 태스크 생성 시 startDate null 핸들링

### DIFF
--- a/jaksim/src/main/java/org/sopt/jaksim/task/service/TaskService.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/task/service/TaskService.java
@@ -46,7 +46,7 @@ public class TaskService {
     public void create(Long categoryId, TaskCreateRequest taskCreateRequest) {
         Task task = Task.create(
                 taskCreateRequest.name(),
-                taskCreateRequest.startDate(),
+                taskCreateRequest.startDate() == null ? LocalDate.now() : taskCreateRequest.startDate(),
                 taskCreateRequest.endDate());
 
         task = taskRepository.save(task);


### PR DESCRIPTION
## 📍 Issue
- closes #137

## ✨ Key Changes
태스크 생성 시 startDate가 null이면 LocalDate.now로 자동 매핑되게 처리했습니다.
3항 연산자를 사용했습니다.

## 💬 To Reviewers



